### PR TITLE
pagination search, fix getCats infinite loop

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -17,9 +17,15 @@ export const getCurrentRandomArchives = createSelector(getApp, (app) => [
   ...app.randomArchives,
 ]);
 
-export const getCurrentSearchArchives = createSelector(getApp, (app) => [
-  ...app.searchArchives,
-]);
+export const getCurrentSearchArchives = createSelector(
+  getApp, 
+  (app) => [...app.searchArchives.archives]
+);
+
+export const getSearchArchivesTotal = createSelector(
+  getApp,
+  (app) => app.searchArchives.total
+);
 
 export const getRandomAndSearchArchives = createSelector(
   getCurrentRandomArchives,
@@ -34,8 +40,8 @@ export const getCurrentArchiveFromRandomAndResults = createSelector(
 );
 
 export const getAmountOfSearchArchives = createSelector(
-  getCurrentSearchArchives,
-  (archives) => archives.length
+  getSearchArchivesTotal,
+  (total) => total
 );
 
 export const getCurrentArciveRandomArchivesIndex = createSelector(
@@ -114,11 +120,11 @@ export const getSearchFilter = createSelector(
 );
 
 export const getMaxPages = createSelector(
-  getAmountOfSearchArchives,
-  (numOfArchive) => (breakpoint) => {
+  getSearchArchivesTotal,
+  (total) => (breakpoint) => {
     const maxNum = getNumArchivesToRender();
-    const maxPageNumber = numOfArchive / maxNum[breakpoint];
-    return numOfArchive % maxNum[breakpoint] === 0
+    const maxPageNumber = total / maxNum[breakpoint];
+    return total % maxNum[breakpoint] === 0
       ? maxPageNumber
       : Math.ceil(maxPageNumber);
   }

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -192,3 +192,8 @@ export const getAutocompleteTags = createSelector(getTags, (tags) =>
     return namespace ? `${namespace}:${text}` : text;
   })
 );
+
+export const getUsePaginatedSearch = createSelector(
+  getApp,
+  (app) => app.settings.usePaginatedSearch
+);

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -18,7 +18,7 @@ export const getCurrentRandomArchives = createSelector(getApp, (app) => [
 ]);
 
 export const getCurrentSearchArchives = createSelector(
-  getApp, 
+  getApp,
   (app) => [...app.searchArchives.archives]
 );
 

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -19,12 +19,12 @@ export const getCurrentRandomArchives = createSelector(getApp, (app) => [
 
 export const getCurrentSearchArchives = createSelector(
   getApp,
-  (app) => [...app.searchArchives.archives]
+  (app) => [...app.searchArchives]
 );
 
 export const getSearchArchivesTotal = createSelector(
   getApp,
-  (app) => app.searchArchives.total
+  (app) => app.searchArchivesTotal
 );
 
 export const getRandomAndSearchArchives = createSelector(

--- a/src/app/slice.js
+++ b/src/app/slice.js
@@ -17,7 +17,10 @@ const initialState = {
   pages: [],
   randomArchives: [],
   renderedPages: [],
-  searchArchives: [],
+  searchArchives: {
+    archives: [],
+    total: 0
+  },
   searchCategory: {},
   searchFilter: "",
   searchPage: 1,
@@ -68,7 +71,10 @@ export const appSlice = createSlice({
       state.randomArchives = [...payload];
     },
     updateSearchArchives: (state, { payload }) => {
-      state.searchArchives = [...payload];
+      state.searchArchives = {
+        archives: [...payload.archives],
+        total: payload.total
+      };
     },
     updateBaseUrl: (state, { payload }) => {
       state.baseUrl = `${payload}`;

--- a/src/app/slice.js
+++ b/src/app/slice.js
@@ -18,10 +18,8 @@ const initialState = {
   pages: [],
   randomArchives: [],
   renderedPages: [],
-  searchArchives: {
-    archives: [],
-    total: 0
-  },
+  searchArchives: [],
+  searchArchivesTotal: 0,
   searchCategory: {},
   searchFilter: "",
   searchPage: 1,
@@ -75,10 +73,8 @@ export const appSlice = createSlice({
       state.randomArchives = [...payload];
     },
     updateSearchArchives: (state, { payload }) => {
-      state.searchArchives = {
-        archives: [...payload.archives],
-        total: payload.total
-      };
+      state.searchArchives = [...payload.archives];
+      state.searchArchivesTotal = payload.total;
     },
     updateBaseUrl: (state, { payload }) => {
       state.baseUrl = `${payload}`;
@@ -145,6 +141,7 @@ export const appSlice = createSlice({
           payload
         ),
       ];
+      state.searchArchivesTotal = Math.max(0, state.searchArchivesTotal - 1);
     },
     updateArchiveTags: (state, { payload }) => {
       if (!payload?.tags) return;

--- a/src/app/slice.js
+++ b/src/app/slice.js
@@ -2,6 +2,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { getNewSearchArchivesArrayAfterDeletingArchiveId } from "../utils";
 import { getSearchStats } from "../storage/search";
+import { loadSearchSettings, saveSearchSettings } from '../storage/searchSettings';
 
 const initialState = {
   archiveOpenedFrom: "random",
@@ -39,6 +40,9 @@ const initialState = {
     search: false,
     random: false,
     images: false,
+  },
+  settings: {
+    usePaginatedSearch: loadSearchSettings(),
   },
 };
 
@@ -171,6 +175,10 @@ export const appSlice = createSlice({
     updateTags: (state, { payload }) => {
       state.tags = [...payload];
     },
+    updateSearchPaginationSetting: (state, { payload }) => {
+      state.settings.usePaginatedSearch = payload;
+      saveSearchSettings(payload);
+    },
   },
 });
 
@@ -198,6 +206,7 @@ export const {
   deleteArchiveFromSearchArchives,
   updateTags,
   updateArchiveTags,
+  updateSearchPaginationSetting,
 } = appSlice.actions;
 
 export default appSlice.reducer;

--- a/src/components/accordions/search-settings-accordion/search-settings-accordion.js
+++ b/src/components/accordions/search-settings-accordion/search-settings-accordion.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { Switch, FormControlLabel } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { getUsePaginatedSearch } from "../../../app/selectors";
+import { updateSearchPaginationSetting } from "../../../app/slice";
+import { BaseAccordion } from "../base-accordion";
+
+export const SearchSettingsAccordion = () => {
+  const dispatch = useDispatch();
+  const usePaginatedSearch = useSelector(getUsePaginatedSearch);
+
+  return (
+    <BaseAccordion title="Search Settings">
+      <FormControlLabel
+        control={
+          <Switch
+            checked={usePaginatedSearch}
+            onChange={(e) => dispatch(updateSearchPaginationSetting(e.target.checked))}
+          />
+        }
+        label="Use server-side pagination for search results"
+      />
+    </BaseAccordion>
+  );
+}; 

--- a/src/components/accordions/search-settings-accordion/search-settings-accordion.js
+++ b/src/components/accordions/search-settings-accordion/search-settings-accordion.js
@@ -2,24 +2,36 @@ import React from "react";
 import { Switch, FormControlLabel } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { getUsePaginatedSearch } from "../../../app/selectors";
-import { updateSearchPaginationSetting } from "../../../app/slice";
+import {
+  updateSearchPaginationSetting,
+  updateLoading,
+  updateSearchArchives,
+  updateSearchPage
+} from "../../../app/slice";
 import { BaseAccordion } from "../base-accordion";
 
 export const SearchSettingsAccordion = () => {
   const dispatch = useDispatch();
   const usePaginatedSearch = useSelector(getUsePaginatedSearch);
 
+  const handlePaginationChange = (e) => {
+    dispatch(updateSearchPaginationSetting(e.target.checked));
+    dispatch(updateSearchArchives({ archives: [], total: 0 }));
+    dispatch(updateSearchPage(1));
+    dispatch(updateLoading({ search: true }));
+  };
+
   return (
     <BaseAccordion title="Search Settings">
       <FormControlLabel
-        control={
+        control={(
           <Switch
             checked={usePaginatedSearch}
-            onChange={(e) => dispatch(updateSearchPaginationSetting(e.target.checked))}
+            onChange={handlePaginationChange}
           />
-        }
+        )}
         label="Use server-side pagination for search results"
       />
     </BaseAccordion>
   );
-}; 
+};

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import Archive from "../archive/archive";
 import { ArchiveInfoDialog } from "../dialogs/archive-info-dialog";
 import { getBaseUrl } from "../../storage/requests";
-import { getCurrentArchiveId, getUsePaginatedSearch } from "../../app/selectors";
+import { getCurrentArchiveId } from "../../app/selectors";
 import { updateInfoDialogArchiveId } from "../../app/slice";
 import { getNumArchivePerRow } from "../../storage/archives";
 import { Loading } from "../loading/loading";

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -46,7 +46,7 @@ export const ArchiveList = ({
     updateArchiveRatingModalState({ open: false, arcId });
   }, []);
 
-  const displayArchives = !usePaginatedSearch && sliceToRender[1] !== null
+  const displayArchives = sliceToRender[1] !== null
     ? archives.slice(sliceToRender[0], sliceToRender[1])
     : archives;
 

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -4,13 +4,12 @@ import { useDispatch, useSelector } from "react-redux";
 import Archive from "../archive/archive";
 import { ArchiveInfoDialog } from "../dialogs/archive-info-dialog";
 import { getBaseUrl } from "../../storage/requests";
-import { getCurrentArchiveId } from "../../app/selectors";
+import { getCurrentArchiveId, getUsePaginatedSearch } from "../../app/selectors";
 import { updateInfoDialogArchiveId } from "../../app/slice";
 import { getNumArchivePerRow } from "../../storage/archives";
 import { Loading } from "../loading/loading";
 import { ArchiveEditDialog } from "../dialogs/archive-edit-dialog/archive-edit-dialog";
 import { ArchiveRatingDialog } from "../dialogs/archive-rating-dialog/archive-rating-dialog";
-import { getUsePaginatedSearch } from "../../app/selectors";
 
 export const ArchiveList = ({
   archives = [],
@@ -35,7 +34,6 @@ export const ArchiveList = ({
     open: false,
     arcId: "",
   });
-  const secondSliceValue = sliceToRender[1] ?? archives.length;
   const baseUrl = getBaseUrl();
   const columns = getNumArchivePerRow();
   const usePaginatedSearch = useSelector(getUsePaginatedSearch);
@@ -60,22 +58,22 @@ export const ArchiveList = ({
           <div id="archives-top" />
           <Loading loading={archivesLoading} label={loadingLabel}>
             {displayArchives.map((archive, idx, arr) => {
-                const { arcid, title, tags } = archive;
-                return (
-                  <Archive
-                    baseUrl={baseUrl}
-                    currentArchiveId={currentArchiveId}
-                    id={arcid}
-                    index={idx}
-                    isSearch={isSearch}
-                    key={`${title}-${arcid}`}
-                    numOfArchivesRendered={arr.length}
-                    onEditClick={onEditClick}
-                    onInfoClick={onInfoClick}
-                    tags={tags}
-                    title={title}
-                  />
-                );
+              const { arcid, title, tags } = archive;
+              return (
+                <Archive
+                  baseUrl={baseUrl}
+                  currentArchiveId={currentArchiveId}
+                  id={arcid}
+                  index={idx}
+                  isSearch={isSearch}
+                  key={`${title}-${arcid}`}
+                  numOfArchivesRendered={arr.length}
+                  onEditClick={onEditClick}
+                  onInfoClick={onInfoClick}
+                  tags={tags}
+                  title={title}
+                />
+              );
             })}
           </Loading>
         </Grid>

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -53,9 +53,7 @@ export const ArchiveList = ({
         <Grid className="mt-0 mb-6" container columns={columns} spacing={2}>
           <div id="archives-top" />
           <Loading loading={archivesLoading} label={loadingLabel}>
-            {archives
-              .slice(sliceToRender[0], secondSliceValue)
-              .map((archive, idx, arr) => {
+            {archives.map((archive, idx, arr) => {
                 const { arcid, title, tags } = archive;
                 return (
                   <Archive
@@ -72,7 +70,7 @@ export const ArchiveList = ({
                     title={title}
                   />
                 );
-              })}
+            })}
           </Loading>
         </Grid>
         {footer}

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -10,6 +10,7 @@ import { getNumArchivePerRow } from "../../storage/archives";
 import { Loading } from "../loading/loading";
 import { ArchiveEditDialog } from "../dialogs/archive-edit-dialog/archive-edit-dialog";
 import { ArchiveRatingDialog } from "../dialogs/archive-rating-dialog/archive-rating-dialog";
+import { getUsePaginatedSearch } from "../../app/selectors";
 
 export const ArchiveList = ({
   archives = [],
@@ -37,6 +38,7 @@ export const ArchiveList = ({
   const secondSliceValue = sliceToRender[1] ?? archives.length;
   const baseUrl = getBaseUrl();
   const columns = getNumArchivePerRow();
+  const usePaginatedSearch = useSelector(getUsePaginatedSearch);
   const onInfoClick = useCallback((arcId) => {
     dispatch(updateInfoDialogArchiveId(arcId));
     updateArchiveInfoModalState({ open: true, arcId });
@@ -46,6 +48,10 @@ export const ArchiveList = ({
     updateArchiveRatingModalState({ open: false, arcId });
   }, []);
 
+  const displayArchives = !usePaginatedSearch && sliceToRender[1] !== null
+    ? archives.slice(sliceToRender[0], sliceToRender[1])
+    : archives;
+
   return (
     <div className="full-height overflow-y-scroll">
       <div className="pt-8 px-4 pb-[75svh]">
@@ -53,7 +59,7 @@ export const ArchiveList = ({
         <Grid className="mt-0 mb-6" container columns={columns} spacing={2}>
           <div id="archives-top" />
           <Loading loading={archivesLoading} label={loadingLabel}>
-            {archives.map((archive, idx, arr) => {
+            {displayArchives.map((archive, idx, arr) => {
                 const { arcid, title, tags } = archive;
                 return (
                   <Archive

--- a/src/components/archive-list/archive-list.js
+++ b/src/components/archive-list/archive-list.js
@@ -36,7 +36,6 @@ export const ArchiveList = ({
   });
   const baseUrl = getBaseUrl();
   const columns = getNumArchivePerRow();
-  const usePaginatedSearch = useSelector(getUsePaginatedSearch);
   const onInfoClick = useCallback((arcId) => {
     dispatch(updateInfoDialogArchiveId(arcId));
     updateArchiveInfoModalState({ open: true, arcId });

--- a/src/components/archive-list/fragments/usePageButtonsLogic.js
+++ b/src/components/archive-list/fragments/usePageButtonsLogic.js
@@ -3,10 +3,9 @@ import { useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useWidth } from "../../../hooks/useWidth";
 import { getMaxPages, getSearchPage, getUsePaginatedSearch } from "../../../app/selectors";
-import { updateSearchPage } from "../../../app/slice";
+import { updateSearchPage, updateLoading } from "../../../app/slice";
 import { setSearchStats } from "../../../storage/search";
 import { updateSearchHistoryLastSearchPage } from "../../../storage/history";
-import { updateLoading } from "../../../app/slice";
 
 const scroll = () => {
   document
@@ -23,7 +22,6 @@ export const usePageButtonsLogic = ({ top }) => {
   const usePaginatedSearch = useSelector(getUsePaginatedSearch);
   const maxPage = useSelector(getMaxPages)(breakpoint);
   const outOfBounds = searchPage > maxPage;
-  const searchPageFromState = useSelector(getSearchPage);
   const topCopy = top ? "top" : "bottom";
   const pages = Array(maxPage)
     .fill(0)

--- a/src/components/archive-list/fragments/usePageButtonsLogic.js
+++ b/src/components/archive-list/fragments/usePageButtonsLogic.js
@@ -6,6 +6,7 @@ import { getMaxPages, getSearchPage } from "../../../app/selectors";
 import { updateSearchPage } from "../../../app/slice";
 import { setSearchStats } from "../../../storage/search";
 import { updateSearchHistoryLastSearchPage } from "../../../storage/history";
+import { updateLoading } from "../../../app/slice";
 
 const scroll = () => {
   document
@@ -35,6 +36,7 @@ export const usePageButtonsLogic = ({ top }) => {
     const newPage = searchPage - 1;
     if (!top) scroll();
     dispatch(updateSearchPage(newPage));
+    dispatch(updateLoading({ search: true }));
     setSearchStats({ page: newPage ?? 1 });
     updateSearchHistoryLastSearchPage(newPage ?? 1);
   }, [top, searchPage]);
@@ -44,6 +46,7 @@ export const usePageButtonsLogic = ({ top }) => {
     if (maxPage !== searchPage) {
       const newPage = searchPage + 1;
       dispatch(updateSearchPage(newPage));
+      dispatch(updateLoading({ search: true }));
       setSearchStats({ page: newPage });
       updateSearchHistoryLastSearchPage(newPage);
     }
@@ -53,6 +56,7 @@ export const usePageButtonsLogic = ({ top }) => {
     (e) => {
       const newPage = Number(e.target.value);
       dispatch(updateSearchPage(newPage));
+      dispatch(updateLoading({ search: true }));
       setSearchStats({ page: newPage });
       updateSearchHistoryLastSearchPage(newPage);
       if (!top) scroll();

--- a/src/components/dialogs/archive-info-dialog/archive-info-dialog.js
+++ b/src/components/dialogs/archive-info-dialog/archive-info-dialog.js
@@ -47,7 +47,7 @@ export const ArchiveInfoDialog = ({ onClose: onCloseProp, arcId, open }) => {
       dispatch(updateCategories(categoriesArray));
       setHasFetchedCategories(true);
     };
-    
+
     if (!hasFetchedCategories) {
       getCats();
     }

--- a/src/components/dialogs/archive-info-dialog/archive-info-dialog.js
+++ b/src/components/dialogs/archive-info-dialog/archive-info-dialog.js
@@ -17,6 +17,7 @@ export const ArchiveInfoDialog = ({ onClose: onCloseProp, arcId, open }) => {
   const categories = useSelector(getStateCategories);
   const [archiveData, setArchiveData] = useState({});
   const [showDelete, setShowDelete] = useState(false);
+  const [hasFetchedCategories, setHasFetchedCategories] = useState(false);
 
   const updateShowDelete = useCallback((show) => setShowDelete(show), [showDelete]);
   const onClose = useCallback(() => {
@@ -44,9 +45,13 @@ export const ArchiveInfoDialog = ({ onClose: onCloseProp, arcId, open }) => {
     const getCats = async () => {
       const categoriesArray = await getCategories();
       dispatch(updateCategories(categoriesArray));
+      setHasFetchedCategories(true);
     };
-    if (!categories.length) getCats();
-  }, [categories]);
+    
+    if (!hasFetchedCategories) {
+      getCats();
+    }
+  }, [hasFetchedCategories]);
 
   const archiveTitle = archiveData?.title ?? "";
   const dialogTitle = (

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -36,18 +36,18 @@ export const Search = ({ display, loading, controller }) => {
   const callNewArchives = useCallback(
     async ({ filter, category, sortby, order }) => {
       const maxPerPage = maxArchivesBreakpoints[breakpoint];
-      
+
       const searchObject = {
         filter,
         sortby,
         order,
-        start: usePaginatedSearch 
+        start: usePaginatedSearch
           ? Math.max(0, (searchPage - 1) * maxPerPage)
           : -1,
         length: usePaginatedSearch ? maxPerPage : -1,
         ...(category && { category }),
       };
-      
+
       const response = await getArchivesBySearch(searchObject);
       dispatch(updateSearchArchives({
         archives: response.data,

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -96,7 +96,7 @@ export const Search = ({ display, loading, controller }) => {
       sliceToRender={!usePaginatedSearch ? [
         (searchPage - 1) * maxArchivesBreakpoints[breakpoint],
         searchPage * maxArchivesBreakpoints[breakpoint]
-      ] : [0, null]}
+      ] : [0, Math.min(searchArchives.length, maxArchivesBreakpoints[breakpoint])]}
       isSearch
       archivesLoading={archivesLoading}
       loadingLabel="Getting archives from search"

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -4,6 +4,7 @@ import { UrlAccordion } from "../accordions/url-accordion/url-accordion";
 import { ArchiveSettingsAccordion } from "../accordions/archive-settings-accordion/archive-settings-accordion";
 import { ImageSettingsAccordion } from "../accordions/image-settings-accordion/image-settings-accordion";
 import { HistoryAccordion } from "../accordions/history-settings-accordion/history-settings-accordion";
+import { SearchSettingsAccordion } from "../accordions/search-settings-accordion/search-settings-accordion";
 
 export const Settings = () => (
   <Grid className="overflow-scroll full-height" container justifyContent="center">
@@ -12,6 +13,7 @@ export const Settings = () => (
         <UrlAccordion />
         <ArchiveSettingsAccordion />
         <ImageSettingsAccordion />
+        <SearchSettingsAccordion />
         <HistoryAccordion />
       </div>
     </Grid>

--- a/src/hooks/useSearchOnLoad/useSearchOnLoad.js
+++ b/src/hooks/useSearchOnLoad/useSearchOnLoad.js
@@ -3,45 +3,74 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   getCurrentRandomArchives,
   getCurrentSearchArchives,
+  getSearchArchivesTotal
 } from "../../app/selectors";
 import { updateSearchArchives } from "../../app/slice";
 import { getArchivesBySearchThrottled } from "../../requests/search";
 import { getSearchStats } from "../../storage/search";
+import { useWidth } from "../../hooks/useWidth";
+import { getNumArchivesToRender } from "../../storage/archives";
 
 export const useSearchOnLoad = () => {
   const dispatch = useDispatch();
-  const { filter, sort: sortby, direction: order, category } = getSearchStats();
+  const breakpoint = useWidth();
+  const { 
+    filter, 
+    sort: sortby, 
+    direction: order, 
+    category,
+    page = 1 
+  } = getSearchStats();
+  
   const searchArchives = useSelector(getCurrentSearchArchives);
+  const searchTotal = useSelector(getSearchArchivesTotal);
   const randomArchives = useSelector(getCurrentRandomArchives);
-  // const { search: isSearchLoading, onLoadSearch } = useSelector(getLoading);
   const [loading, setLoading] = useState(false);
   const [searchFilter, setSearchFilter] = useState(null);
   const [controller] = useState(new AbortController());
-  const searchLoaded = searchArchives.length;
 
-  const results = { results: searchArchives, loading, controller };
+  const results = { 
+    results: searchArchives, 
+    total: searchTotal,
+    loading, 
+    controller 
+  };
 
   const callNewArchives = useCallback(async (search) => {
     setLoading(true);
-    const arcs = await getArchivesBySearchThrottled(
-      {
-        filter: search,
-        sortby,
-        order,
-        start: -1,
-        ...(category && { category }),
-      },
-      controller
-    ).catch(() => /* find a better way of handling errors */ [
-      { id: "error", title: "something went wrong, try searching again" },
-    ]);
-    dispatch(updateSearchArchives(arcs));
-    setLoading(false);
-  }, []);
+    const maxPerPage = getNumArchivesToRender()[breakpoint];
+    const start = Math.max(0, (page - 1) * maxPerPage);
+
+    try {
+      const response = await getArchivesBySearchThrottled(
+        {
+          filter: search,
+          sortby,
+          order,
+          start,
+          length: maxPerPage,
+          ...(category && { category }),
+        },
+        controller
+      );
+      
+      dispatch(updateSearchArchives({
+        archives: response.data,
+        total: response.recordsFiltered
+      }));
+    } catch (error) {
+      dispatch(updateSearchArchives({
+        archives: [{ id: "error", title: "something went wrong, try searching again" }],
+        total: 0
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [breakpoint, page]);
 
   useEffect(() => {
     if (
-      !searchLoaded &&
+      !searchTotal &&  // 改为检查总数而不是当前页的结果
       randomArchives.length &&
       !loading &&
       searchFilter !== filter
@@ -49,7 +78,7 @@ export const useSearchOnLoad = () => {
       callNewArchives(filter);
       setSearchFilter(filter);
     }
-  }, [searchLoaded, randomArchives, loading, searchFilter, filter]);
+  }, [searchTotal, randomArchives, loading, searchFilter, filter]);
 
   return results;
 };

--- a/src/hooks/useSearchOnLoad/useSearchOnLoad.js
+++ b/src/hooks/useSearchOnLoad/useSearchOnLoad.js
@@ -9,20 +9,20 @@ import {
 import { updateSearchArchives } from "../../app/slice";
 import { getArchivesBySearchThrottled } from "../../requests/search";
 import { getSearchStats } from "../../storage/search";
-import { useWidth } from "../../hooks/useWidth";
+import { useWidth } from "../useWidth";
 import { getNumArchivesToRender } from "../../storage/archives";
 
 export const useSearchOnLoad = () => {
   const dispatch = useDispatch();
   const breakpoint = useWidth();
-  const { 
-    filter, 
-    sort: sortby, 
-    direction: order, 
+  const {
+    filter,
+    sort: sortby,
+    direction: order,
     category,
-    page = 1 
+    page = 1
   } = getSearchStats();
-  
+
   const searchArchives = useSelector(getCurrentSearchArchives);
   const searchTotal = useSelector(getSearchArchivesTotal);
   const randomArchives = useSelector(getCurrentRandomArchives);
@@ -30,58 +30,52 @@ export const useSearchOnLoad = () => {
   const [loading, setLoading] = useState(false);
   const [searchFilter, setSearchFilter] = useState(null);
   const [controller] = useState(new AbortController());
+  const [searchLoaded, setSearchLoaded] = useState(false);
 
-  const results = { 
-    results: searchArchives, 
+  const results = {
+    results: searchArchives,
     total: searchTotal,
-    loading, 
-    controller 
+    loading,
+    controller
   };
 
   const callNewArchives = useCallback(async (search) => {
     setLoading(true);
     const maxPerPage = getNumArchivesToRender()[breakpoint];
 
-    try {
-      const response = await getArchivesBySearchThrottled(
-        {
-          filter: search,
-          sortby,
-          order,
-          start: usePaginatedSearch 
-            ? Math.max(0, (page - 1) * maxPerPage)
-            : -1,
-          length: usePaginatedSearch ? maxPerPage : -1,
-          ...(category && { category }),
-        },
-        controller
-      );
-      
-      dispatch(updateSearchArchives({
-        archives: response.data,
-        total: usePaginatedSearch ? response.recordsFiltered : response.data.length
-      }));
-    } catch (error) {
-      dispatch(updateSearchArchives({
-        archives: [{ id: "error", title: "something went wrong, try searching again" }],
-        total: 0
-      }));
-    } finally {
-      setLoading(false);
-    }
+    const response = await getArchivesBySearchThrottled(
+      {
+        filter: search,
+        sortby,
+        order,
+        start: usePaginatedSearch
+          ? Math.max(0, (page - 1) * maxPerPage)
+          : -1,
+        length: usePaginatedSearch ? maxPerPage : -1,
+        ...(category && { category }),
+      },
+      controller
+    );
+
+    dispatch(updateSearchArchives({
+      archives: response.data,
+      total: usePaginatedSearch ? response.recordsFiltered : response.data.length
+    }));
+    setLoading(false);
   }, [breakpoint, page, usePaginatedSearch]);
 
   useEffect(() => {
     if (
-      !searchTotal &&  // 改为检查总数而不是当前页的结果
+      !searchLoaded &&
       randomArchives.length &&
       !loading &&
       searchFilter !== filter
     ) {
       callNewArchives(filter);
       setSearchFilter(filter);
+      setSearchLoaded(true);
     }
-  }, [searchTotal, randomArchives, loading, searchFilter, filter]);
+  }, [searchLoaded, randomArchives, loading, searchFilter, filter]);
 
   return results;
 };

--- a/src/requests/search.js
+++ b/src/requests/search.js
@@ -6,7 +6,7 @@ import { httpOrHttps } from "../utils";
 import { getRequestConfig } from "./request-utils";
 
 export const getArchivesBySearch = async (
-  { filter, sortby, order, start = 0, length = 25, category },
+  { filter, sortby, order, start = -1, length = -1, category },
   controller
 ) => {
   const params = new URLSearchParams();

--- a/src/requests/search.js
+++ b/src/requests/search.js
@@ -6,7 +6,7 @@ import { httpOrHttps } from "../utils";
 import { getRequestConfig } from "./request-utils";
 
 export const getArchivesBySearch = async (
-  { filter, sortby, order, start = -1, category },
+  { filter, sortby, order, start = 0, length = 25, category },
   controller
 ) => {
   const params = new URLSearchParams();
@@ -14,6 +14,7 @@ export const getArchivesBySearch = async (
   params.append("sortby", sortby);
   params.append("order", order);
   params.append("start", start);
+  params.append("length", length);
   if (category) params.append("category", category);
 
   const categories = await axios({
@@ -22,7 +23,7 @@ export const getArchivesBySearch = async (
     ...(controller && { signal: controller.signal }),
   });
 
-  return categories?.data?.data ?? [];
+  return categories?.data ?? { data: [], recordsFiltered: 0 };
 };
 
 export const getArchivesByLastRead = async () => {

--- a/src/storage/constants.js
+++ b/src/storage/constants.js
@@ -16,6 +16,8 @@ export const DISPLAY_METHOD_IMAGES = "DISPLAY_METHOD_IMAGES";
 
 export const SEARCH_STATS = "SEARCH_STATS";
 
+export const USE_PAGINATED_SEARCH = "USE_PAGINATED_SEARCH";
+
 export const SEARCH_STATS_DEFAULT = {
   filter: "",
   page: 1,

--- a/src/storage/searchSettings.js
+++ b/src/storage/searchSettings.js
@@ -6,5 +6,5 @@ export const saveSearchSettings = (settings) => {
 
 export const loadSearchSettings = () => {
   const savedSetting = localStorage.getItem(USE_PAGINATED_SEARCH);
-  return savedSetting ? JSON.parse(savedSetting) : true; 
-}; 
+  return savedSetting ? JSON.parse(savedSetting) : true;
+};

--- a/src/storage/searchSettings.js
+++ b/src/storage/searchSettings.js
@@ -1,0 +1,10 @@
+import { USE_PAGINATED_SEARCH } from "./constants";
+
+export const saveSearchSettings = (settings) => {
+  localStorage.setItem(USE_PAGINATED_SEARCH, JSON.stringify(settings));
+};
+
+export const loadSearchSettings = () => {
+  const savedSetting = localStorage.getItem(USE_PAGINATED_SEARCH);
+  return savedSetting ? JSON.parse(savedSetting) : true; 
+}; 


### PR DESCRIPTION
I'm managing up to 17000 archives with lanraragi. lanraragi-react-web is loading very slowly when I switch to search page because it fetch all archive info at one time. To make a better eexperience, I try to modify some code to make it query archived as needed.

I find when I don't have any categories on lanrargi, lanraragi-react-web will call getCats again and again. This PR also fixed it